### PR TITLE
fix: pre-commit codespell hook

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,0 +1,2 @@
+[codespell]
+ignore-words-list = pullrequests,hist


### PR DESCRIPTION
Codespell plugin failing the `pullRequest` directive in the pull-request
workflow.

Fixes: #8